### PR TITLE
Imitation variant is now an instance of Variant

### DIFF
--- a/lib/Kumite/Controller.php
+++ b/lib/Kumite/Controller.php
@@ -279,6 +279,8 @@ class Controller
 
     private function imitationVariant($testKey)
     {
-        return $this->cookieAdapter->getCookie(self::IMITATE_COOKIE_PREFIX . $testKey);
+        if ($variantKey = $this->cookieAdapter->getCookie(self::IMITATE_COOKIE_PREFIX . $testKey)) {
+            return new Variant($variantKey);
+        }
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -96,7 +96,10 @@ class ControllerTest extends BaseTest
     {
         $this->expectImitateCookie();
         $c = $this->createController();
-        $this->assertEquals($c->variant('myTest'), 'newVariant');
+        $variant = $c->variant('myTest');
+
+        $this->assertEquals($variant->key(), 'newVariant');
+        $this->assertEquals($variant, 'newVariant');
     }
 
     public function testAddEventCookie()


### PR DESCRIPTION
Fix to make an imitation variant an instance of `Variant`. This ensures the expected return from `Kumite::variant` is an instance of `Variant` and not a string when imitating.
